### PR TITLE
Allow spaces in source directories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Dan Helfman <witten@torsion.org>: Main developer
 Alexander Görtz: Python 3 compatibility
 Henning Schroeder: Copy editing
 Robin `ypid` Schneider: Support additional options of Borg
+Dan Poirier: Spaces in source directories

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Here's an example config file:
 [location]
 # Space-separated list of source directories to backup.
 # Globs are expanded.
-source_directories: /home /etc /var/log/syslog*
+# Spaces in names can be escaped with a backslash.
+source_directories: /home /etc /var/log/syslog* /dir\ with\ spaces
 
 # Path to local or remote backup repository.
 repository: user@backupserver:sourcehostname.borg

--- a/borgmatic/borg.py
+++ b/borgmatic/borg.py
@@ -13,6 +13,8 @@ from borgmatic.verbosity import VERBOSITY_SOME, VERBOSITY_LOTS
 
 
 COMMAND = 'borg'
+ESCAPED_SPACE = r'\ '
+TEMP_REPLACEMENT_FOR_ESCAPED_SPACE = 'SLASH_ESCAPED_SPACE'
 
 
 def initialize(storage_config, command=COMMAND):
@@ -28,10 +30,13 @@ def create_archive(
 ):
     '''
     Given an excludes filename (or None), a vebosity flag, a storage config dict, a space-separated
-    list of source directories, a local or remote repository path, and a command to run, create an
-    attic archive.
+    list of source directories (spaces escaped with a backslash not treated as separators), a local
+    or remote repository path, and a command to run, create an attic archive.
     '''
-    sources = re.split('\s+', source_directories)
+    # To support escaping spaces in directory name, temporarily replace them
+    temp_source_directories = source_directories.replace(ESCAPED_SPACE, TEMP_REPLACEMENT_FOR_ESCAPED_SPACE)
+    sources = re.split('\s+', temp_source_directories)
+    sources = [s.replace(TEMP_REPLACEMENT_FOR_ESCAPED_SPACE, ' ') for s in sources]
     sources = tuple(chain.from_iterable(glob(x) or [x] for x in sources))
     exclude_flags = ('--exclude-from', excludes_filename) if excludes_filename else ()
     compression = storage_config.get('compression', None)

--- a/borgmatic/tests/unit/test_borg.py
+++ b/borgmatic/tests/unit/test_borg.py
@@ -87,6 +87,21 @@ def test_create_archive_with_two_spaces_in_source_directories():
     )
 
 
+def test_create_archive_with_escaped_spaces_in_source_directories():
+    insert_subprocess_mock(('borg', 'create', 'repo::host-now', 'foo dir', 'bar'))
+    insert_platform_mock()
+    insert_datetime_mock()
+
+    module.create_archive(
+        excludes_filename=None,
+        verbosity=None,
+        storage_config={},
+        source_directories=r'foo\ dir  bar',
+        repository='repo',
+        command='borg',
+    )
+
+
 def test_create_archive_with_none_excludes_filename_should_call_borg_without_excludes():
     insert_subprocess_mock(CREATE_COMMAND_WITHOUT_EXCLUDES)
     insert_platform_mock()

--- a/borgmatic/tests/unit/test_config.py
+++ b/borgmatic/tests/unit/test_config.py
@@ -152,7 +152,7 @@ def test_validate_configuration_format_with_extra_option_should_raise():
 
 def test_parse_section_options_should_return_section_options():
     parser = flexmock()
-    parser.should_receive('get').with_args('section', 'foo').and_return('value')
+    parser.should_receive('get').with_args('section', 'foo').and_return(r'value\ baz')
     parser.should_receive('getint').with_args('section', 'bar').and_return(1)
     parser.should_receive('getboolean').never()
     parser.should_receive('has_option').with_args('section', 'foo').and_return(True)
@@ -170,7 +170,7 @@ def test_parse_section_options_should_return_section_options():
 
     assert config == OrderedDict(
         (
-            ('foo', 'value'),
+            ('foo', r'value\ baz'),
             ('bar', 1),
         )
     )

--- a/sample/config
+++ b/sample/config
@@ -1,7 +1,8 @@
 [location]
 # Space-separated list of source directories to backup.
 # Globs are expanded.
-source_directories: /home /etc /var/log/syslog*
+# Spaces in names can be escaped with a backslash.
+source_directories: /home /etc /var/log/syslog* /dir\ with\ spaces
 
 # Stay in same file system (do not cross mount points).
 #one_file_system: True


### PR DESCRIPTION
Use a backslash to escape a space to treat it as part of
the directory name and not a separator.