### PR TITLE
Added archive-prefix to config.yaml

### DIFF
--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -82,11 +82,13 @@ def create_archive(
         VERBOSITY_SOME: ('--info', '--stats',),
         VERBOSITY_LOTS: ('--debug', '--list', '--stats'),
     }.get(verbosity, ())
+    archive_prefix = storage_config.get('archive-prefix', '')
 
     full_command = (
         'borg', 'create',
-        '{repository}::{hostname}-{timestamp}'.format(
+        '{repository}::{archive_prefix}{hostname}-{timestamp}'.format(
             repository=repository,
+            archive_prefix=archive_prefix,
             hostname=platform.node(),
             timestamp=datetime.now().isoformat(),
         ),

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -88,6 +88,13 @@ map:
                 type: scalar
                 desc: Umask to be used for borg create.
                 example: 0077
+            archive-prefix:
+                type: scalar
+                desc: |
+                    Prefix to be added to the archive name.
+                    The complete archive name is : '{archive-prefix}{hostname}-{timestamp}'
+                    Defaults to ''
+                example: prefix1-
     retention:
         desc: |
             Retention policy for how many backups to keep in each category. See
@@ -119,7 +126,9 @@ map:
                 example: 1
             prefix:
                 type: scalar
-                desc: When pruning, only consider archive names starting with this prefix.
+                desc: |
+                    When pruning, only consider archive names starting with this prefix.
+                    The complete archive name is : '{archive-prefix}{hostname}-{timestamp}'
                 example: sourcehostname
     consistency:
         desc: |

--- a/borgmatic/tests/unit/borg/test_create.py
+++ b/borgmatic/tests/unit/borg/test_create.py
@@ -344,3 +344,22 @@ def test_create_archive_with_glob_should_call_borg_with_expanded_directories():
         },
         storage_config={},
     )
+
+
+def test_create_archive_with_prefix():
+    flexmock(module).should_receive('_write_exclude_file').and_return(None)
+    flexmock(module).should_receive('_make_exclude_flags').and_return(())
+    insert_subprocess_mock(('borg', 'create', 'repo::PREFIX-host-now', 'foo', 'bar'))
+    insert_platform_mock()
+    insert_datetime_mock()
+
+    module.create_archive(
+        verbosity=None,
+        repository='repo',
+        location_config={
+            'source_directories': ['foo', 'bar'],
+            'repositories': ['repo'],
+            'exclude_patterns': None,
+        },
+        storage_config={'archive-prefix': 'PREFIX-'},
+    )


### PR DESCRIPTION
This PR adds `archive-prefix` to [storage], which is prefixed to the archive name.
Also, the way the current archive name is created ({archive_prefix}{hostname}-{timestamp}) is added to the generated conf comments for easier access.

Storage and prune prefixes are independent and archive-prefix is set by default to ''. This means that it's backwards compatible and no config changes are required for those who like current setup.


Usecase: mostly having the opportunity to use multiple config files on the same host and being able to distinguish the archives


See: https://tree.taiga.io/project/witten-borgmatic/issue/28

---

The alternative is to use a single prefix for both storage and retention.
We would need the archive name to be changed from {hostname}-{timestamp} to {prefix}-{timestamp} with prefix defaulting to {hostname}. So, either:
 1. no breaking changes: [retention].prefix is the source of truth 
 2. breaking changes: [storage].prefix is the source of truth and [retention].prefix is deprecated

I can create another PR if this alternative is preferred.
