### PR TITLE
Added storage.archive_name to config

### DIFF
--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -82,15 +82,17 @@ def create_archive(
         VERBOSITY_SOME: ('--info', '--stats',),
         VERBOSITY_LOTS: ('--debug', '--list', '--stats'),
     }.get(verbosity, ())
+    default_archive_name = '{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}'
+    archive_name = storage_config.get('archive_name', default_archive_name)
 
     full_command = (
         'borg', 'create',
-        '{repository}::{hostname}-{timestamp}'.format(
+        '{repository}::{archive_name}'.format(
             repository=repository,
-            hostname=platform.node(),
-            timestamp=datetime.now().isoformat(),
+            archive_name=archive_name,
         ),
     ) + sources + exclude_flags + compression_flags + one_file_system_flags + \
         remote_path_flags + umask_flags + verbosity_flags
 
     subprocess.check_call(full_command)
+

--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -1,8 +1,6 @@
-from datetime import datetime
 import glob
 import itertools
 import os
-import platform
 import subprocess
 import tempfile
 
@@ -82,17 +80,16 @@ def create_archive(
         VERBOSITY_SOME: ('--info', '--stats',),
         VERBOSITY_LOTS: ('--debug', '--list', '--stats'),
     }.get(verbosity, ())
-    default_archive_name = '{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}'
-    archive_name = storage_config.get('archive_name', default_archive_name)
+    default_archive_name_format = '{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}'
+    archive_name_format = storage_config.get('archive_name_format', default_archive_name_format)
 
     full_command = (
         'borg', 'create',
-        '{repository}::{archive_name}'.format(
+        '{repository}::{archive_name_format}'.format(
             repository=repository,
-            archive_name=archive_name,
+            archive_name_format=archive_name_format,
         ),
     ) + sources + exclude_flags + compression_flags + one_file_system_flags + \
         remote_path_flags + umask_flags + verbosity_flags
 
     subprocess.check_call(full_command)
-

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -91,10 +91,10 @@ map:
             archive_name:
                 type: scalar
                 desc: |
-                    Name of the archive. Borg placeholders can be used, see
+                    Name of the archive. Borg placeholders can be used. See
                     https://borgbackup.readthedocs.io/en/stable/usage.html#borg-help-placeholders
                     Default is "{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}"
-                example: "Documents-{hostname}-{now}"
+                example: "{hostname}-documents-{now}"
     retention:
         desc: |
             Retention policy for how many backups to keep in each category. See
@@ -128,7 +128,7 @@ map:
                 type: scalar
                 desc: |
                     When pruning, only consider archive names starting with this prefix.
-                    Borg placeholders can be used, see
+                    Borg placeholders can be used. See
                     https://borgbackup.readthedocs.io/en/stable/usage.html#borg-help-placeholders
                 example: sourcehostname
     consistency:

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -88,7 +88,7 @@ map:
                 type: scalar
                 desc: Umask to be used for borg create.
                 example: 0077
-            archive_name:
+            archive_name_format:
                 type: scalar
                 desc: |
                     Name of the archive. Borg placeholders can be used. See

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -88,6 +88,13 @@ map:
                 type: scalar
                 desc: Umask to be used for borg create.
                 example: 0077
+            archive_name:
+                type: scalar
+                desc: |
+                    Name of the archive. Borg placeholders can be used, see
+                    https://borgbackup.readthedocs.io/en/stable/usage.html#borg-help-placeholders
+                    Default is "{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}"
+                example: "Documents-{hostname}-{now}"
     retention:
         desc: |
             Retention policy for how many backups to keep in each category. See
@@ -119,7 +126,10 @@ map:
                 example: 1
             prefix:
                 type: scalar
-                desc: When pruning, only consider archive names starting with this prefix.
+                desc: |
+                    When pruning, only consider archive names starting with this prefix.
+                    Borg placeholders can be used, see
+                    https://borgbackup.readthedocs.io/en/stable/usage.html#borg-help-placeholders
                 example: sourcehostname
     consistency:
         desc: |

--- a/borgmatic/tests/unit/borg/test_create.py
+++ b/borgmatic/tests/unit/borg/test_create.py
@@ -48,16 +48,6 @@ def insert_subprocess_mock(check_call_command, **kwargs):
     subprocess.should_receive('check_call').with_args(check_call_command, **kwargs).once()
 
 
-def insert_platform_mock():
-    flexmock(module.platform).should_receive('node').and_return('host')
-
-
-def insert_datetime_mock():
-    flexmock(module).datetime = flexmock().should_receive('now').and_return(
-        flexmock().should_receive('isoformat').and_return('now').mock
-    ).mock
-
-
 def test_make_exclude_flags_includes_exclude_patterns_filename_when_given():
     exclude_flags = module._make_exclude_flags(
         location_config={'exclude_patterns': ['*.pyc', '/var']},
@@ -128,15 +118,13 @@ def test_make_exclude_flags_is_empty_when_config_has_no_excludes():
     assert exclude_flags == ()
 
 
-CREATE_COMMAND = ('borg', 'create', 'repo::host-now', 'foo', 'bar')
+CREATE_COMMAND = ('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'bar')
 
 
 def test_create_archive_should_call_borg_with_parameters():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND)
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -155,8 +143,6 @@ def test_create_archive_with_exclude_patterns_should_call_borg_with_excludes():
     flexmock(module).should_receive('_write_exclude_file').and_return(flexmock(name='/tmp/excludes'))
     flexmock(module).should_receive('_make_exclude_flags').and_return(exclude_flags)
     insert_subprocess_mock(CREATE_COMMAND + exclude_flags)
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -174,8 +160,6 @@ def test_create_archive_with_verbosity_some_should_call_borg_with_info_parameter
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--info', '--stats',))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=VERBOSITY_SOME,
@@ -193,8 +177,6 @@ def test_create_archive_with_verbosity_lots_should_call_borg_with_debug_paramete
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--debug', '--list', '--stats'))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=VERBOSITY_LOTS,
@@ -212,8 +194,6 @@ def test_create_archive_with_compression_should_call_borg_with_compression_param
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--compression', 'rle'))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -231,8 +211,6 @@ def test_create_archive_with_one_file_system_should_call_borg_with_one_file_syst
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--one-file-system',))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -251,8 +229,6 @@ def test_create_archive_with_remote_path_should_call_borg_with_remote_path_param
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--remote-path', 'borg1'))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -271,8 +247,6 @@ def test_create_archive_with_umask_should_call_borg_with_umask_parameters():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(CREATE_COMMAND + ('--umask', '740'))
-    insert_platform_mock()
-    insert_datetime_mock()
 
     module.create_archive(
         verbosity=None,
@@ -289,9 +263,7 @@ def test_create_archive_with_umask_should_call_borg_with_umask_parameters():
 def test_create_archive_with_source_directories_glob_expands():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::host-now', 'foo', 'food'))
-    insert_platform_mock()
-    insert_datetime_mock()
+    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'food'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return(['foo', 'food'])
 
     module.create_archive(
@@ -309,9 +281,7 @@ def test_create_archive_with_source_directories_glob_expands():
 def test_create_archive_with_non_matching_source_directories_glob_passes_through():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::host-now', 'foo*'))
-    insert_platform_mock()
-    insert_datetime_mock()
+    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo*'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return([])
 
     module.create_archive(
@@ -329,9 +299,7 @@ def test_create_archive_with_non_matching_source_directories_glob_passes_through
 def test_create_archive_with_glob_should_call_borg_with_expanded_directories():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::host-now', 'foo', 'food'))
-    insert_platform_mock()
-    insert_datetime_mock()
+    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'food'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return(['foo', 'food'])
 
     module.create_archive(
@@ -343,4 +311,42 @@ def test_create_archive_with_glob_should_call_borg_with_expanded_directories():
             'exclude_patterns': None,
         },
         storage_config={},
+    )
+
+
+def test_create_archive_with_archive_name():
+    flexmock(module).should_receive('_write_exclude_file').and_return(None)
+    flexmock(module).should_receive('_make_exclude_flags').and_return(())
+    insert_subprocess_mock(('borg', 'create', 'repo::ARCHIVE_NAME', 'foo', 'bar'))
+
+    module.create_archive(
+        verbosity=None,
+        repository='repo',
+        location_config={
+            'source_directories': ['foo', 'bar'],
+            'repositories': ['repo'],
+            'exclude_patterns': None,
+        },
+        storage_config={
+            'archive_name': 'ARCHIVE_NAME',
+        },
+    )
+
+
+def test_create_archive_with_archive_name_accepts_borg_placeholders():
+    flexmock(module).should_receive('_write_exclude_file').and_return(None)
+    flexmock(module).should_receive('_make_exclude_flags').and_return(())
+    insert_subprocess_mock(('borg', 'create', 'repo::Documents_{hostname}-{now}', 'foo', 'bar'))
+
+    module.create_archive(
+        verbosity=None,
+        repository='repo',
+        location_config={
+            'source_directories': ['foo', 'bar'],
+            'repositories': ['repo'],
+            'exclude_patterns': None,
+        },
+        storage_config={
+            'archive_name': 'Documents_{hostname}-{now}',
+        },
     )

--- a/borgmatic/tests/unit/borg/test_create.py
+++ b/borgmatic/tests/unit/borg/test_create.py
@@ -118,7 +118,8 @@ def test_make_exclude_flags_is_empty_when_config_has_no_excludes():
     assert exclude_flags == ()
 
 
-CREATE_COMMAND = ('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'bar')
+DEFAULT_ARCHIVE_NAME = '{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}'
+CREATE_COMMAND = ('borg', 'create', 'repo::{}'.format(DEFAULT_ARCHIVE_NAME), 'foo', 'bar')
 
 
 def test_create_archive_should_call_borg_with_parameters():
@@ -263,7 +264,7 @@ def test_create_archive_with_umask_should_call_borg_with_umask_parameters():
 def test_create_archive_with_source_directories_glob_expands():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'food'))
+    insert_subprocess_mock(('borg', 'create', 'repo::{}'.format(DEFAULT_ARCHIVE_NAME), 'foo', 'food'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return(['foo', 'food'])
 
     module.create_archive(
@@ -281,7 +282,7 @@ def test_create_archive_with_source_directories_glob_expands():
 def test_create_archive_with_non_matching_source_directories_glob_passes_through():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo*'))
+    insert_subprocess_mock(('borg', 'create', 'repo::{}'.format(DEFAULT_ARCHIVE_NAME), 'foo*'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return([])
 
     module.create_archive(
@@ -299,7 +300,7 @@ def test_create_archive_with_non_matching_source_directories_glob_passes_through
 def test_create_archive_with_glob_should_call_borg_with_expanded_directories():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
-    insert_subprocess_mock(('borg', 'create', 'repo::{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}', 'foo', 'food'))
+    insert_subprocess_mock(('borg', 'create', 'repo::{}'.format(DEFAULT_ARCHIVE_NAME), 'foo', 'food'))
     flexmock(module.glob).should_receive('glob').with_args('foo*').and_return(['foo', 'food'])
 
     module.create_archive(
@@ -314,7 +315,7 @@ def test_create_archive_with_glob_should_call_borg_with_expanded_directories():
     )
 
 
-def test_create_archive_with_archive_name():
+def test_create_archive_with_archive_name_format_without_placeholders():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(('borg', 'create', 'repo::ARCHIVE_NAME', 'foo', 'bar'))
@@ -328,12 +329,12 @@ def test_create_archive_with_archive_name():
             'exclude_patterns': None,
         },
         storage_config={
-            'archive_name': 'ARCHIVE_NAME',
+            'archive_name_format': 'ARCHIVE_NAME',
         },
     )
 
 
-def test_create_archive_with_archive_name_accepts_borg_placeholders():
+def test_create_archive_with_archive_name_format_accepts_borg_placeholders():
     flexmock(module).should_receive('_write_exclude_file').and_return(None)
     flexmock(module).should_receive('_make_exclude_flags').and_return(())
     insert_subprocess_mock(('borg', 'create', 'repo::Documents_{hostname}-{now}', 'foo', 'bar'))
@@ -347,6 +348,6 @@ def test_create_archive_with_archive_name_accepts_borg_placeholders():
             'exclude_patterns': None,
         },
         storage_config={
-            'archive_name': 'Documents_{hostname}-{now}',
+            'archive_name_format': 'Documents_{hostname}-{now}',
         },
     )

--- a/borgmatic/tests/unit/borg/test_prune.py
+++ b/borgmatic/tests/unit/borg/test_prune.py
@@ -32,6 +32,24 @@ def test_make_prune_flags_should_return_flags_from_config():
     assert tuple(result) == BASE_PRUNE_FLAGS
 
 
+def test_make_prune_flags_accepts_prefix_with_placeholders():
+    retention_config = OrderedDict(
+        (
+            ('keep_daily', 1),
+            ('prefix', 'Documents_{hostname}-{now}'),
+        )
+    )
+
+    result = module._make_prune_flags(retention_config)
+
+    expected = (
+        ('--keep-daily', '1'),
+        ('--prefix', 'Documents_{hostname}-{now}'),
+    )
+
+    assert tuple(result) == expected
+
+
 PRUNE_COMMAND = (
     'borg', 'prune', 'repo', '--keep-daily', '1', '--keep-weekly', '2', '--keep-monthly', '3',
 )
@@ -77,6 +95,7 @@ def test_prune_archives_with_verbosity_lots_should_call_borg_with_debug_paramete
         verbosity=VERBOSITY_LOTS,
         retention_config=retention_config,
     )
+
 
 def test_prune_archives_with_remote_path_should_call_borg_with_remote_path_parameters():
     retention_config = flexmock()


### PR DESCRIPTION
Related to #15 , https://tree.taiga.io/project/witten-borgmatic/issue/28

"Repository (or Archive) URLs, –prefix and –remote-path values support these placeholders" (https://borgbackup.readthedocs.io/en/stable/usage.html#borg-help-placeholders).

So, an even better way than adding a prefix or handling hostname and timestamp inside borgmatic is to use borg's placeholders which accomplishes the same thing as the old 
```
'{hostname}-{timestamp}'.format(...) 
```

This allows the usecase for both a prefix, label, removing timestamp and all of that, simply by changing storage.archive_name to something else, be it `MYPREFIX-{hostname}-{now}`, `{hostname}-MY_LABEL-{now}-{borgversion}` or whatever.

The default archive_name is now 
```
{hostname}-{now:%Y-%m-%dT%H:%M:%S.%f}
```
which is the same as the previously used 
```
'{hostname}-{timestamp}'.format(hostname=platform.node(), timestamp=datetime.now().isoformat())
```
but everything depends on borg's implementation of placeholders.

---

I deleted test_create platform and date mocks as hostname and timestamp are not generated in borgmatic, but the placeholders get passed to borg, so this made the mocks useless.

----

I'm closing #15 as this achieves the same goal in a better way.