### PR TITLE
Support for user hooks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Henning Schroeder: Copy editing
 Michele Lazzeri: Custom archive names
 Robin `ypid` Schneider: Support additional options of Borg
 Scott Squires: Custom archive names
+Johannes Feichtner: Support for user hooks

--- a/borgmatic/commands/hook.py
+++ b/borgmatic/commands/hook.py
@@ -1,7 +1,7 @@
 import subprocess
 
 
-def exec_cmd(config):
-    if config and config.get('enable_hook', None) is True:
-        for cmd in config.get('exec_hook'):
+def execute_hook(commands):
+    if commands:
+        for cmd in commands:
             subprocess.check_call(cmd, shell=True)

--- a/borgmatic/commands/hook.py
+++ b/borgmatic/commands/hook.py
@@ -1,0 +1,7 @@
+import subprocess
+
+
+def exec_cmd(config):
+    if config and config.get('enable_hook', None) is True:
+        for cmd in config.get('exec_hook'):
+            subprocess.check_call(cmd, shell=True)

--- a/borgmatic/config/generate.py
+++ b/borgmatic/config/generate.py
@@ -24,7 +24,7 @@ def _schema_to_sample_configuration(schema, level=0):
     for each section based on the schema "desc" description.
     '''
     example = schema.get('example')
-    if example:
+    if example is not None:
         return example
 
     config = yaml.comments.CommentedMap([

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -161,48 +161,24 @@ map:
         desc: |
             Shell commands or scripts to execute before and after a backup or if an error has occurred.
             IMPORTANT: All provided commands and scripts are executed with user permissions of borgmatic.
-            Do not forget to set secure permissions on this file as well as on any script listed (chmod 0600) to
+            Do not forget to set secure permissions on this file as well as on any script listed (chmod 0700) to
             prevent potential shell injection or privilege escalation.
         map:
             before_backup:
-                desc: Options for a hook to execute before the backup process is started.
-                map:
-                    enable_hook:
-                        type: bool
-                        desc: Define whether the commands in "exec_hook" should be run before creating a backup.
-                        example: false
-                    exec_hook:
-                        seq:
-                            - type: scalar
-                        desc: |
-                            List of one or more shell commands or scripts to run in advance.
-                        example:
-                            - echo "The number of days since the year's beginning is `date +%j`."
+                seq:
+                    - type: scalar
+                desc: List of one or more shell commands or scripts to execute before creating a backup.
+                example:
+                    - echo "`date` - Starting a backup job."
             after_backup:
-                desc: Options for a hook to execute after the backup process has completed.
-                map:
-                    enable_hook:
-                        type: bool
-                        desc: Define whether the commands in "exec_hook" should be run after creating a backup.
-                        example: false
-                    exec_hook:
-                        seq:
-                            - type: scalar
-                        desc: |
-                            List of one or more shell commands or scripts to run afterwards.
-                        example:
-                            - echo "The number of seconds elapsed since 01/01/1970 is `date +%s`."
+                seq:
+                    - type: scalar
+                desc: List of one or more shell commands or scripts to execute after creating a backup.
+                example:
+                    - echo "`date` - Backup created."
             on_error:
-                desc: Options for a hook to execute in case an exception has occurred.
-                map:
-                    enable_hook:
-                        type: bool
-                        desc: Define whether the commands in "exec_hook" should be run on error.
-                        example: false
-                    exec_hook:
-                        seq:
-                            - type: scalar
-                        desc: |
-                            List of one or more shell commands or scripts to run on error.
-                        example:
-                            - echo "Error while creating a backup. `date`."
+                seq:
+                    - type: scalar
+                desc: List of one or more shell commands or scripts to execute in case an exception has occurred.
+                example:
+                    - echo "`date` - Error while creating a backup."

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -157,3 +157,52 @@ map:
                 desc: Restrict the number of checked archives to the last n. Applies only to the
                       "archives" check.
                 example: 3
+    hooks:
+        desc: |
+            Shell commands or scripts to execute before and after a backup or if an error has occurred.
+            IMPORTANT: All provided commands and scripts are executed with user permissions of borgmatic.
+            Do not forget to set secure permissions on this file as well as on any script listed (chmod 0600) to
+            prevent potential shell injection or privilege escalation.
+        map:
+            before_backup:
+                desc: Options for a hook to execute before the backup process is started.
+                map:
+                    enable_hook:
+                        type: bool
+                        desc: Define whether the commands in "exec_hook" should be run before creating a backup.
+                        example: false
+                    exec_hook:
+                        seq:
+                            - type: scalar
+                        desc: |
+                            List of one or more shell commands or scripts to run in advance.
+                        example:
+                            - echo "The number of days since the year's beginning is `date +%j`."
+            after_backup:
+                desc: Options for a hook to execute after the backup process has completed.
+                map:
+                    enable_hook:
+                        type: bool
+                        desc: Define whether the commands in "exec_hook" should be run after creating a backup.
+                        example: false
+                    exec_hook:
+                        seq:
+                            - type: scalar
+                        desc: |
+                            List of one or more shell commands or scripts to run afterwards.
+                        example:
+                            - echo "The number of seconds elapsed since 01/01/1970 is `date +%s`."
+            on_error:
+                desc: Options for a hook to execute in case an exception has occurred.
+                map:
+                    enable_hook:
+                        type: bool
+                        desc: Define whether the commands in "exec_hook" should be run on error.
+                        example: false
+                    exec_hook:
+                        seq:
+                            - type: scalar
+                        desc: |
+                            List of one or more shell commands or scripts to run on error.
+                        example:
+                            - echo "Error while creating a backup. `date`."

--- a/borgmatic/config/validate.py
+++ b/borgmatic/config/validate.py
@@ -49,9 +49,6 @@ def parse_configuration(config_filename, schema_filename):
     for section_name, section_schema in schema['map'].items():
         for field_name, field_schema in section_schema['map'].items():
             field_schema.pop('example', None)
-            if 'map' in field_schema:
-                for field_name1, field_schema1 in field_schema['map'].items():
-                    field_schema1.pop('example', None)
 
     validator = pykwalify.core.Core(source_data=config, schema_data=schema)
     parsed_result = validator.validate(raise_exception=False)

--- a/borgmatic/config/validate.py
+++ b/borgmatic/config/validate.py
@@ -48,7 +48,10 @@ def parse_configuration(config_filename, schema_filename):
     # simply remove all examples before passing the schema to pykwalify.
     for section_name, section_schema in schema['map'].items():
         for field_name, field_schema in section_schema['map'].items():
-            field_schema.pop('example')
+            field_schema.pop('example', None)
+            if 'map' in field_schema:
+                for field_name1, field_schema1 in field_schema['map'].items():
+                    field_schema1.pop('example', None)
 
     validator = pykwalify.core.Core(source_data=config, schema_data=schema)
     parsed_result = validator.validate(raise_exception=False)

--- a/borgmatic/config/validate.py
+++ b/borgmatic/config/validate.py
@@ -44,7 +44,14 @@ def parse_configuration(config_filename, schema_filename):
     except yaml.error.YAMLError as error:
         raise Validation_error(config_filename, (str(error),))
 
-    clean_pykwalify(schema)
+    # pykwalify gets angry if the example field is not a string. So rather than bend to its will,
+    # simply remove all examples before passing the schema to pykwalify.
+    for section_name, section_schema in schema['map'].items():
+        for field_name, field_schema in section_schema['map'].items():
+            field_schema.pop('example', None)
+            if 'map' in field_schema:
+                for field_name1, field_schema1 in field_schema['map'].items():
+                    field_schema1.pop('example', None)
 
     validator = pykwalify.core.Core(source_data=config, schema_data=schema)
     parsed_result = validator.validate(raise_exception=False)
@@ -53,17 +60,6 @@ def parse_configuration(config_filename, schema_filename):
         raise Validation_error(config_filename, validator.validation_errors)
 
     return parsed_result
-
-
-def clean_pykwalify(schema):
-    '''
-    pykwalify gets angry if the example field is not a string. So rather than bend to its will,
-    simply remove all examples before passing the schema to pykwalify.
-    '''
-    for section_name, section_schema in schema['map'].items():
-        section_schema.pop('example', None)
-        if 'map' in section_schema:
-            clean_pykwalify(section_schema)
 
 
 def display_validation_error(validation_error):

--- a/borgmatic/tests/unit/borg/test_hook.py
+++ b/borgmatic/tests/unit/borg/test_hook.py
@@ -3,8 +3,8 @@ from flexmock import flexmock
 from borgmatic.commands import hook as module
 
 
-def test_exec_cmd():
+def test_execute_hook_invokes_each_command():
     subprocess = flexmock(module.subprocess)
     subprocess.should_receive('check_call').with_args(':', shell=True).once()
 
-    module.exec_cmd({'enable_hook': True, 'exec_hook': [':']})
+    module.execute_hook([':'])

--- a/borgmatic/tests/unit/borg/test_hook.py
+++ b/borgmatic/tests/unit/borg/test_hook.py
@@ -1,0 +1,10 @@
+from flexmock import flexmock
+
+from borgmatic.commands import hook as module
+
+
+def test_exec_cmd():
+    subprocess = flexmock(module.subprocess)
+    subprocess.should_receive('check_call').with_args(':', shell=True).once()
+
+    module.exec_cmd({'enable_hook': True, 'exec_hook': [':']})


### PR DESCRIPTION
This PR adds support for user-defined shell scripts or single commands to be executed before and after a backup, or if an error has occurred. The intended use case is just as described in two existing issues [1, 2].  

Using the "before_backup", "after_backup", and "on_error" sections in the config file, it is possible to list one or multiple commands to execute. For example, this can be used to send emails after successful / failed backups, check disk space, execute mysqldump prior to creating a backup, etc.

For a better overview I've split the implementation into 3 commits:

1. af38fdea01a145a6c3437df0193823bb04d20e21 enables the value of the "example" fields in schema.yaml to be false by default, e.g. when used in conjunction with _type: bool_. 
This comes in handy to demonstrate the use of hooks in the generated default config. As the user has to customize the commands to execute anyway, it seems advisable to disable the hooks by default.

2. 55fd81332455270a94392adda3502fafd0b8b655 is the actual implementation for hooks. For now, I've moved _exec_cmd()_ into the separate file hook.py. As it's only 4 lines it might as well fit into borgmatic.py but I guess that's a matter of taste :-)
 
3. 7685613d280817c5efd954c715d12f339fa2753f removes "example" fields recursively from _schema_. It might be a bit overkill just for user hooks but I think it's useful anyway, considering that future config versions could add further "map" sections regardless of their position in the hierarchy.

It may not be missed that shell support in borgmatic also has some security implications:

- In the worst case scenario, a config file specifies a shell script that is also writable by attackers. For example, lets assume the specified script resides in the document root of a vHost user and the provided web application is not exactly secure. After successful exploitation an attacker might place his own commands into the script and wait for the next cron run of borgmatic. In that case, an attacker's payload would be executed with the same permissions as borgmatic. If borgmatic is called with higher-level permissions, the consequences could be fatal.

- In another scenario, imagine config files having insecure file permissions. An attacker couldn't only read the encryption passphrase but might also be able to insert arbitrary shell commands. The implications would be the same as above.

In summary, I think user hooks would be a very useful extension to borgmatic **if used with care**.  Anyone enabling them should understand the security implications. 

[1] https://tree.taiga.io/project/witten-borgmatic/issue/16
[2] https://tree.taiga.io/project/witten-borgmatic/issue/38