### PR TITLE
Add Gitlab CI pyinstaller standalone binary autobuild

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+image: danieldent/pyinstaller
+
+build-linux-amd64:
+  script:
+  - python3 setup.py install
+  - pyinstaller -n borgmatic --onefile --add-data borgmatic/config/schema.yaml:borgmatic/config pyinstaller-main.py
+  artifacts:
+    paths:
+    - dist/borgmatic

--- a/pyinstaller-main.py
+++ b/pyinstaller-main.py
@@ -1,0 +1,2 @@
+from borgmatic.commands.borgmatic import main
+main()


### PR DESCRIPTION
I used https://github.com/cdrx/docker-pyinstaller for some hints on how to do this.

It builds standalone binaries much like the borg project distributes. Creating a standalone build of borgmatic means it's possible use borg via borgmatic on a machine by simply copying two files onto it.

I've only created a build for Linux amd64; there's no reason other platforms couldn't be supported. The docker-pyinstaller repo I linked above will provide a bit of guidance to anyone looking to add support for other platforms.