### PR TITLE
Fixed ruamel version (not working with ruamel >=0.15.5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     install_requires=(
         'pykwalify>=1.6.0',
-        'ruamel.yaml>0.15.0,<0.16.0',
+        'ruamel.yaml>0.15.0,<=0.15.4',
         'setuptools',
     ),
     tests_require=(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,4 @@ flexmock==0.10.2
 pykwalify==1.6.1
 pytest==3.6.3
 pytest-cov==2.5.1
-ruamel.yaml>0.15.0,<0.16.0
+ruamel.yaml>0.15.0,<=0.15.4


### PR DESCRIPTION
Ruamel 0.15.5 (released about 13 hours ago) not working correctly in conjunction with pykwalify.
With a default config, when borgmatic starts 

_pykwalify.errors.RuleError: <RuleError: error code 4: Value for keyword 'map/mapping' is not a dict: Path: '/'>_

Installing ruamel.yaml==0.15.4 seem to solve the issue.