### PR TITLE
fixed error: /bin/ash: root: not found

### DIFF
--- a/sample/cron-alpine/borgmatic
+++ b/sample/cron-alpine/borgmatic
@@ -1,3 +1,3 @@
 # You can drop this file into /etc/cron.d/ to run borgmatic nightly.
 
-0 3 * * * root PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic
+0 3 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic

--- a/sample/cron/borgmatic
+++ b/sample/cron/borgmatic
@@ -1,3 +1,3 @@
 # You can drop this file into /etc/cron.d/ to run borgmatic nightly.
 
-0 3 * * * root PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic
+0 3 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic


### PR DESCRIPTION
This example is better suited for docker images based on alpine-linux. although just specifying the executable `borgmatic` is more general purpose i think. like this:
`0 3 * * * borgmatic 2>&1`

The output would show up in `docker logs` if you would run this an a container. Also in the syslog in any other scenario. 