### PR TITLE
Support read special parameter

### DIFF
--- a/borgmatic/borg/create.py
+++ b/borgmatic/borg/create.py
@@ -145,6 +145,7 @@ def create_archive(
         + (('--compression', compression) if compression else ())
         + (('--remote-ratelimit', str(remote_rate_limit)) if remote_rate_limit else ())
         + (('--one-file-system',) if location_config.get('one_file_system') else ())
+        + (('--read-special',) if location_config.get('read_special') else ())
         + (('--nobsdflags',) if location_config.get('bsd_flags') is False else ())
         + (('--files-cache', files_cache) if files_cache else ())
         + (('--remote-path', remote_path) if remote_path else ())

--- a/borgmatic/config/schema.yaml
+++ b/borgmatic/config/schema.yaml
@@ -22,6 +22,13 @@ map:
                 type: bool
                 desc: Stay in same file system (do not cross mount points).
                 example: true
+            read_special:
+                type: bool
+                desc: |
+                    Use borg's --read-special flag to allow backup of block and other special
+                    devices. Use with caution, as it will lead to problems if used when
+                    backing up special devices such as /dev/zero
+                example: false
             bsd_flags:
                 type: bool
                 desc: Record bsdflags (e.g. NODUMP, IMMUTABLE) in archive. Defaults to true.

--- a/borgmatic/tests/unit/borg/test_create.py
+++ b/borgmatic/tests/unit/borg/test_create.py
@@ -455,6 +455,27 @@ def test_create_archive_with_one_file_system_calls_borg_with_one_file_system_par
     )
 
 
+def test_create_archive_with_read_special_calls_borg_with_read_special_parameters():
+    flexmock(module).should_receive('_expand_directories').and_return(('foo', 'bar')).and_return(())
+    flexmock(module).should_receive('_write_pattern_file').and_return(None)
+    flexmock(module).should_receive('_make_pattern_flags').and_return(())
+    flexmock(module).should_receive('_make_exclude_flags').and_return(())
+    insert_subprocess_mock(CREATE_COMMAND + ('--read-special',))
+
+    module.create_archive(
+        verbosity=None,
+        dry_run=False,
+        repository='repo',
+        location_config={
+            'source_directories': ['foo', 'bar'],
+            'repositories': ['repo'],
+            'read_special': True,
+            'exclude_patterns': None,
+        },
+        storage_config={},
+    )
+
+
 def test_create_archive_with_bsd_flags_true_calls_borg_without_nobsdflags_parameter():
     flexmock(module).should_receive('_expand_directories').and_return(('foo', 'bar')).and_return(())
     flexmock(module).should_receive('_write_pattern_file').and_return(None)


### PR DESCRIPTION
In response to a [discussion about libvirt and `--read-special` support](https://projects.torsion.org/witten/borgmatic/issues/80#issuecomment-817), I have modified borgmatic to support this feature.
One may wish to embellish the `read_special` YAML description with some more information if it's not detailed or specific enough.