### PR TITLE
check_archives does not take json parameter

### DIFF
--- a/borgmatic/commands/borgmatic.py
+++ b/borgmatic/commands/borgmatic.py
@@ -191,8 +191,7 @@ def _run_commands_on_repository(
             storage,
             consistency,
             local_path=local_path,
-            remote_path=remote_path,
-            json=args.json
+            remote_path=remote_path
         )
     if args.list:
         logger.info('{}: Listing archives'.format(repository))


### PR DESCRIPTION
Borgmatic crashed on my machine because check_archives does not expect a parameter `json`.