### PR TITLE
Add link to  openSUSE packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ you're using Python 3, as borgmatic does not support Python 2.
  * [Fedora](https://bodhi.fedoraproject.org/updates/?search=borgmatic)
  * [Arch Linux](https://aur.archlinux.org/packages/borgmatic/)
  * [OpenBSD](http://ports.su/sysutils/borgmatic)
+ * [openSUSE](https://software.opensuse.org/package/borgmatic)
+
 <br><br>
 
 


### PR DESCRIPTION
Add a link to the software.opensuse.org page were both official and community packages of borgmatic are available to be downloaded or installed using 1-click-install.