### PR TITLE
Fix error on cleanup multiple database dumps

### DIFF
--- a/borgmatic/hooks/dump.py
+++ b/borgmatic/hooks/dump.py
@@ -71,10 +71,10 @@ def remove_database_dumps(dump_path, databases, database_type_name, log_prefix, 
             continue
 
         os.remove(dump_filename)
-        dump_path = os.path.dirname(dump_filename)
+        dump_file_dir = os.path.dirname(dump_filename)
 
-        if len(os.listdir(dump_path)) == 0:
-            os.rmdir(dump_path)
+        if len(os.listdir(dump_file_dir)) == 0:
+            os.rmdir(dump_file_dir)
 
 
 def convert_glob_patterns_to_borg_patterns(patterns):


### PR DESCRIPTION
Hallo witten,

I have found a little error in your *remove_database_dumps* function. If you have multiple dumps of a database type, the function parameter *dump_path* is overwritten in foreach loop with dump_file.
In the second loop, the database name is appended a second time to dump_path.

This pull request fixed the error in the cleanup routine for database dumps.

regards
Raphael 