### PR TITLE
Use --remote-path, --debug and --info when checking for repo existence

### DIFF
--- a/borgmatic/borg/init.py
+++ b/borgmatic/borg/init.py
@@ -23,7 +23,13 @@ def initialize_repository(
     whether the repository should be append-only, and the storage quota to use, initialize the
     repository. If the repository already exists, then log and skip initialization.
     '''
-    info_command = (local_path, 'info', repository)
+    info_command = (
+        (local_path, 'info')
+        + (('--info',) if logger.getEffectiveLevel() == logging.INFO else ())
+        + (('--debug',) if logger.isEnabledFor(logging.DEBUG) else ())
+        + (('--remote-path', remote_path) if remote_path else ())
+        + (repository,)
+    )
     logger.debug(' '.join(info_command))
 
     try:


### PR DESCRIPTION
User-defined remote paths and verbosity settings are not being honoured in the first call to borg in borgmatic's init command. This call is used to check whether the repo already exists or not.

I've noticed this while creating a new repo and trying to use a remote-path set to force the use of a newer version of borg on a remote host instead of an old version, leading to scary error messages from an ancient version of borg during repo init.