### PR TITLE
Fixed Broken pg_dumpall Restore

### DIFF
--- a/borgmatic/hooks/postgresql.py
+++ b/borgmatic/hooks/postgresql.py
@@ -93,14 +93,25 @@ def restore_database_dumps(databases, log_prefix, location_config, dry_run):
         dump_filename = dump.make_database_dump_filename(
             make_dump_path(location_config), database['name'], database.get('hostname')
         )
-        restore_command = (
-            ('pg_restore', '--no-password', '--clean', '--if-exists', '--exit-on-error')
-            + (('--host', database['hostname']) if 'hostname' in database else ())
-            + (('--port', str(database['port'])) if 'port' in database else ())
-            + (('--username', database['username']) if 'username' in database else ())
-            + ('--dbname', database['name'])
-            + (dump_filename,)
-        )
+        if database['name'] == 'all':
+            restore_command = (
+                ('psql', '--no-password', '--clean', '--if-exists', '--exit-on-error')
+                + (('--host', database['hostname']) if 'hostname' in database else ())
+                + (('--port', str(database['port'])) if 'port' in database else ())
+                + (('--username', database['username']) if 'username' in database else ())
+                + ('--dbname', database['name'])
+                + (dump_filename,)
+            )
+        else:
+            restore_command = (
+                ('pg_restore', '--no-password', '--clean', '--if-exists', '--exit-on-error')
+                + (('--host', database['hostname']) if 'hostname' in database else ())
+                + (('--port', str(database['port'])) if 'port' in database else ())
+                + (('--username', database['username']) if 'username' in database else ())
+                + ('--dbname', database['name'])
+                + (dump_filename,)
+            )
+
         extra_environment = {'PGPASSWORD': database['password']} if 'password' in database else None
         analyze_command = (
             ('psql', '--no-password', '--quiet')

--- a/borgmatic/hooks/postgresql.py
+++ b/borgmatic/hooks/postgresql.py
@@ -103,7 +103,7 @@ def restore_database_dumps(databases, log_prefix, location_config, dry_run):
         )
         restore_command = (
             ('psql' if all_databases else 'pg_restore', '--no-password')
-            + (('--if-exists', '--exit-on-error', '--clean', '--create', '--dbname', database['name']) if not all_databases else ())
+            + (('--if-exists', '--exit-on-error', '--clean', '--dbname', database['name']) if not all_databases else ())
             + (('--host', database['hostname']) if 'hostname' in database else ())
             + (('--port', str(database['port'])) if 'port' in database else ())
             + (('--username', database['username']) if 'username' in database else ())

--- a/borgmatic/hooks/postgresql.py
+++ b/borgmatic/hooks/postgresql.py
@@ -34,7 +34,12 @@ def dump_databases(databases, log_prefix, location_config, dry_run):
         )
         all_databases = bool(name == 'all')
         command = (
-            ('pg_dumpall' if all_databases else 'pg_dump', '--no-password', '--clean','--if-exists')
+            (
+                'pg_dumpall' if all_databases else 'pg_dump',
+                '--no-password',
+                '--clean',
+                '--if-exists',
+            )
             + ('--file', dump_filename)
             + (('--host', database['hostname']) if 'hostname' in database else ())
             + (('--port', str(database['port'])) if 'port' in database else ())
@@ -99,15 +104,20 @@ def restore_database_dumps(databases, log_prefix, location_config, dry_run):
             + (('--host', database['hostname']) if 'hostname' in database else ())
             + (('--port', str(database['port'])) if 'port' in database else ())
             + (('--username', database['username']) if 'username' in database else ())
+            + (('--dbname', database['name']) if not all_databases else ())
             + ('--command', 'ANALYZE')
         )
         restore_command = (
             ('psql' if all_databases else 'pg_restore', '--no-password')
-            + (('--if-exists', '--exit-on-error', '--clean', '--dbname', database['name']) if not all_databases else ())
+            + (
+                ('--if-exists', '--exit-on-error', '--clean', '--dbname', database['name'])
+                if not all_databases
+                else ()
+            )
             + (('--host', database['hostname']) if 'hostname' in database else ())
             + (('--port', str(database['port'])) if 'port' in database else ())
             + (('--username', database['username']) if 'username' in database else ())
-            + ( ('-f', dump_filename) if all_databases else (dump_filename,) )
+            + (('-f', dump_filename) if all_databases else (dump_filename,))
         )
         extra_environment = {'PGPASSWORD': database['password']} if 'password' in database else None
 

--- a/tests/end-to-end/test_database.py
+++ b/tests/end-to-end/test_database.py
@@ -29,6 +29,10 @@ hooks:
           hostname: postgresql
           username: postgres
           password: test
+        - name: all
+          hostname: postgresql
+          username: postgres
+          password: test
     mysql_databases:
         - name: test
           hostname: mysql


### PR DESCRIPTION
When the database name is set to 'all', borgmatic uses `pg_dumpall` instead of `pg_dump` to dump the database. `pg_dumpall` outputs a plain-text format and `pg_restore` does not accept that format. To run these plain-text outputs, `psql` is needed instead.

This pull request implements that. Thanks!