### PR TITLE
tests/integration/test_execute: use plain Python rather than xxd

### DIFF
--- a/tests/integration/test_execute.py
+++ b/tests/integration/test_execute.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import sys
 
 import pytest
 from flexmock import flexmock
@@ -134,7 +135,8 @@ def test_log_outputs_vents_other_processes_when_one_exits():
     flexmock(module).should_receive('command_for_process').and_return('grep')
 
     process = subprocess.Popen(
-        ['xxd', '-l', '40000', '-p', '/dev/urandom'], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        [sys.executable, '-c', "import random, string; print(''.join(random.choice(string.ascii_letters) for _ in range(40000)))"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     other_process = subprocess.Popen(
         ['true'], stdin=process.stdout, stdout=subprocess.PIPE, stderr=subprocess.STDOUT


### PR DESCRIPTION
This allows test_execute not to depend on either vim or /dev/urandom.