### PR TITLE
Added more strict ProtectHome to systemd unit

### DIFF
--- a/sample/systemd/borgmatic.service
+++ b/sample/systemd/borgmatic.service
@@ -37,8 +37,11 @@ SystemCallErrorNumber=EPERM
 # system read-only be default and uncomment 'ReadWritePaths' for the required write access.
 # Add local repositroy paths to the list of 'ReadWritePaths' like '-/mnt/my_backup_drive'.
 ProtectSystem=full
-# ProtectHome=read-only
-# ReadWritePaths=-/root/.config/borg -/root/.cache/borg -/root/.borgmatic
+# ReadWritePaths=-/mnt/my_backup_drive
+# ReadOnlyPaths=-/var/lib/my_backup_source
+# This will mount a tmpfs on top of /root and pass through needed paths
+# ProtectHome=tmpfs
+# BindPaths=-/root/.cache/borg -/root/.cache/borg -/root/.borgmatic
 
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH CAP_NET_RAW
 


### PR DESCRIPTION
This commit changes the comment in sample systemd service.

Using a combination of 'ProtectHome' and 'BindPaths' it's possible to
hide the irrelevant paths inside /root from borgmatic service when it is
run.

ReadWritePaths are suggested to be used only for paths that contain borg
repositories and the backup sources can be specified as ReadOnlyPaths.